### PR TITLE
Generalize shared library prefix/suffix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,5 +20,8 @@ add_executable(pvm2csv src/pvm2csv.c)
 add_dependencies(copususer libpvm)
 add_dependencies(pvm2csv libpvm)
 
-target_link_libraries(copususer "${CMAKE_SOURCE_DIR}/target/release/libopus.so")
-target_link_libraries(pvm2csv "${CMAKE_SOURCE_DIR}/target/release/libopus.so")
+set(RUST_TARGET_DIR "${CMAKE_SOURCE_DIR}/target/release")
+set(LIBOPUS "${RUST_TARGET_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}opus${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+target_link_libraries(copususer ${LIBOPUS})
+target_link_libraries(pvm2csv ${LIBOPUS})


### PR DESCRIPTION
Shared libraries are named `libfoo.so` on POSIX OSes, but on MacOS
they're named `libfoo.dylib` (and on Windows I think they're just
`foo.dll`?). Generalize this CMake file to work on non-POSIX platforms.